### PR TITLE
Replace `libxslt-dev` for `libxslt1-dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Check out the Vagrant section lower down in the readme if you want to get starte
 
 on Ubuntu 14.04 LTS
 
-```apt-get install -y ruby ruby-dev postgresql-9.3-postgis-2.1 postgresql-server-dev-all postgresql-contrib build-essential git-core libxml2-dev libxslt-dev imagemagick libmapserver1 gdal-bin libgdal-dev ruby-mapscript nodejs```
+```apt-get install -y ruby ruby-dev postgresql-9.3-postgis-2.1 postgresql-server-dev-all postgresql-contrib build-essential git-core libxml2-dev libxslt1-dev imagemagick libmapserver1 gdal-bin libgdal-dev ruby-mapscript nodejs```
 
 Due to a bug with the gdal gem, you _may_ need to disable a few flags from your ruby rbconfig.rb see https://github.com/zhm/gdal-ruby/issues/4 for more information
 


### PR DESCRIPTION
Console says,
>  Note, selecting 'libxslt1-dev' instead of 'libxslt-dev'
>  The following NEW packages will be installed:
>    libxslt1-dev

Also described below :)
http://packages.ubuntu.com/en/trusty/libxslt-dev