### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,5 +2,7 @@
 # coding styles between different editors and IDEs
 # editorconfig.org
 
+root = true
+
 [*]
 trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+[*]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Keep consistency about trailing whitespace triming.
This may be helpful for the case of  https://github.com/timwaters/mapwarper/pull/120#issuecomment-296447875 and save communication costs.

How about this?
