### PR TITLE
Update ruby on Vagrant VM and related document

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ to get and install the virtual machine - this will also install the libraries an
 After that runs, type vagrant ssh to login and then you can
 
     cd /srv/mapwarper
-    rails c
+    bundle exec rails c
 
 Create a user in the console, as shown above and then exit
 
-    rails s -b 0.0.0.0 -p 3000
+    bundle exec rails s -b 0.0.0.0 -p 3000
 
 to start the server, running on port 3000
 

--- a/lib/vagrant/provision.sh
+++ b/lib/vagrant/provision.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+VAGRANT_HOME=/home/vagrant
+RUBY_VERSION=2.2.1
+
 # make sure we have up-to-date packages
 apt-get update
 
@@ -25,14 +28,60 @@ apt-get install -y ruby1.9.1 libruby1.9.1 ruby1.9.1-dev ri1.9.1 \
 
 #ruby gdal needs the build Werror=format-security removed currently
 sed -i 's/-Werror=format-security//g' /usr/lib/ruby/1.9.1/x86_64-linux/rbconfig.rb
- 
-gem1.9.1 install bundle
+
+# https://github.com/rbenv/ruby-build/wiki#suggested-build-environment
+apt-get install -y  \
+  autoconf \
+  bison \
+  libffi-dev \
+  libgdal-dev \
+  libgdbm-dev \
+  libgdbm3 \
+  libncurses5-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libxslt1-dev \
+  libyaml-dev \
+  python-dev \
+  ruby-dev \
+  zlib1g-dev
+
+# install and enable rbenv
+if [[ ! -d $VAGRANT_HOME/.rbenv ]]; then
+  sudo -u vagrant -H git clone https://github.com/rbenv/rbenv.git $VAGRANT_HOME/.rbenv
+  echo 'export PATH="'$VAGRANT_HOME'/.rbenv/bin:$PATH"' | sudo -u vagrant tee -a $VAGRANT_HOME/.bashrc
+  echo 'eval "$(rbenv init -)"' | sudo -u vagrant tee -a $VAGRANT_HOME/.bashrc
+fi
+if [[ ! -d $VAGRANT_HOME/.rbenv/plugins/ruby-build ]]; then
+  sudo -u vagrant -H git clone https://github.com/rbenv/ruby-build.git $VAGRANT_HOME/.rbenv/plugins/ruby-build
+  echo 'export PATH="'$VAGRANT_HOME'/.rbenv/plugins/ruby-build/bin:$PATH"' | sudo -u vagrant tee -a $VAGRANT_HOME/.bashrc
+fi
+
+# the local executives
+RBENV=$VAGRANT_HOME/.rbenv/bin/rbenv
+GEM=$VAGRANT_HOME/.rbenv/shims/gem
+BUNDLE=$VAGRANT_HOME/.rbenv/shims/bundle
+
+# get and switch ruby version
+sudo -u vagrant -H $RBENV install $RUBY_VERSION
+sudo -u vagrant -H $RBENV global $RUBY_VERSION
+sudo -u vagrant -H $RBENV rehash
+
+# link depended modules from global into local
+sudo -u vagrant ln -s \
+  /usr/lib/x86_64-linux-gnu/ruby/vendor_ruby/2.0.0/mapscript.so \
+  $VAGRANT_HOME/.rbenv/versions/$RUBY_VERSION/lib/ruby/vendor_ruby/2.2.0/x86_64-linux/mapscript.so
+
+# install module management package
+# gem1.9.1 install bundle
+sudo -u vagrant -H $GEM install bundler
 
 ## install the bundle necessary for mapwarper
 pushd /srv/mapwarper
 
-# do bundle install as a convenience
-sudo -u vagrant -H bundle install 
+# do bundle install as a convenience and put the dependencies outside to accelerate `bundle exec` command
+sudo -u vagrant -H $BUNDLE install --path $VAGRANT_HOME/mapwarper_dependencies
+
 # create user and database for openstreetmap-website
 db_user_exists=`sudo -u postgres psql postgres -tAc "select 1 from pg_roles where rolname='vagrant'"`
 if [ "$db_user_exists" != "1" ]; then
@@ -58,5 +107,6 @@ fi
 
 echo "now migrating database. This may take a few minutes"
 # migrate the database to the latest version
-sudo -u vagrant -H bundle exec rake db:migrate
+sudo -u vagrant -H $BUNDLE exec rake db:migrate
+
 popd


### PR DESCRIPTION
Related to #131 and maybe #104.
This PR adopts `rbenv` the version switcher, updates ruby and make Vagrant setup easy.
