### PR TITLE
Load OpenStreetMap tiles over https

### DIFF
--- a/app/assets/javascripts/layers.js.erb
+++ b/app/assets/javascripts/layers.js.erb
@@ -41,7 +41,7 @@ function get_tilesathome_osm_url (bounds) {
 }
 
 
-var mapnik = new OpenLayers.Layer.TMS("OpenStreetMap", "http://tile.openstreetmap.org/", {
+var mapnik = new OpenLayers.Layer.TMS("OpenStreetMap", "https://tile.openstreetmap.org/", {
     type: 'png',
     getURL: osm_getTileURL,
     displayOutsideMaxExtent: true,


### PR DESCRIPTION
This will solve security warnings in the browser, and send a proper HTTP Referer, which avoids tarpitting on the OpenStreetMap side, which will speed up the OSM layer considerably.